### PR TITLE
Add Reachability pod dependency

### DIFF
--- a/Bully.podspec
+++ b/Bully.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.dependency 'SocketRocket'
+  s.dependency 'Reachability'
 end


### PR DESCRIPTION
Building with Bully pod fails because it's missing Reachability, needed in 18042c85a69ad3; this adds it as a dependency.

I tested by using this podspec in my local ~/.cocoapods/master, built fine afterwards
