### PR TITLE
Send text websocket messages instead of binary messages

### DIFF
--- a/Bully/BLYClient.m
+++ b/Bully/BLYClient.m
@@ -216,7 +216,12 @@
 							eventName, @"event",
 							dictionary, @"data",
 							nil];
-	[self.webSocket send:[NSJSONSerialization dataWithJSONObject:object options:0 error:nil]];
+
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:object options:NSJSONReadingAllowFragments error:nil];
+    // We need to send the data as UTF8 encoded string,
+    // otherwise it will be interpreted as binary data
+    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+	[self.webSocket send:jsonString];
 }
 
 


### PR DESCRIPTION
This caused some issues over the weekend, because the Pusher service was not expecting binary messages to be sent.
