### PR TITLE
Better connection close handling based on pusher protocol

### DIFF
--- a/Bully/BLYClient.h
+++ b/Bully/BLYClient.h
@@ -13,6 +13,9 @@
 
 @interface BLYClient : NSObject
 
+// error domain for client errors
+extern NSString *const BLYClientErrorDomain;
+
 @property (nonatomic, strong, readonly) NSString *socketID;
 @property (nonatomic, weak, readonly) id<BLYClientDelegate> delegate;
 @property (nonatomic, assign) BOOL automaticallyReconnect; // Default is YES
@@ -52,6 +55,7 @@
 
 - (void)bullyClientDidConnect:(BLYClient *)client;
 - (void)bullyClient:(BLYClient *)client didReceiveError:(NSError *)error;
-- (void)bullyClientDidDisconnect:(BLYClient *)client;
+- (void)bullyClientDidDisconnect:(BLYClient *)client __attribute__((deprecated("Use bullyClient:didDisconnectWithError instead")));
+- (void)bullyClient:(BLYClient *)client didDisconnectWithError:(NSError *)error;
 
 @end

--- a/Bully/BLYClient.m
+++ b/Bully/BLYClient.m
@@ -16,6 +16,8 @@
 #import <UIKit/UIApplication.h> // For background notificaitons
 #endif
 
+NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
+
 @implementation BLYClient {
 	Reachability *_reachability;
 
@@ -160,7 +162,7 @@
 		return;
 	}
 
-	NSString *urlString = [[NSString alloc] initWithFormat:@"wss://%@/app/%@?protocol=5&client=bully&version=%@&flash=false", self.hostName, self.appKey, [[self class] version]];
+	NSString *urlString = [[NSString alloc] initWithFormat:@"wss://%@/app/%@?protocol=6&client=bully&version=%@&flash=false", self.hostName, self.appKey, [[self class] version]];
 	NSURL *url = [[NSURL alloc] initWithString:urlString];
 	self.webSocket = [[SRWebSocket alloc] initWithURL:url];
 	[self.webSocket open];
@@ -176,27 +178,9 @@
 		return;
 	}
 
-	self.webSocket = nil;
-	if ([self.delegate respondsToSelector:@selector(bullyClientDidDisconnect:)]) {
-		[self.delegate bullyClientDidDisconnect:self];
-	}
-	self.socketID = nil;
-
-	// If we shouldn't auto reconnect, stop
-	if (!_automaticallyReconnect) {
-		return;
-	}
-
-	// If it disconnected but Pusher is reachable
-	if ([_reachability isReachable]) {
-#if TARGET_OS_IPHONE
-		// If the app is in the background and we automatically disconnect in the background, don't reconnect. Duh.
-		if (_appIsBackgrounded && _automaticallyDisconnectInBackground) {
-			return;
-		}
-#endif
-		[self connect];
-	}
+	// in case the connection was disconnected
+    // do not reconnect automatically
+    [self _handleDisconnectAllowAutomaticReconnect:NO error:nil];
 }
 
 
@@ -239,6 +223,53 @@
 	}
 
 	[self.connectedChannels removeObjectForKey:channel.name];
+}
+
+
+- (void)_handleDisconnectAllowAutomaticReconnect:(BOOL)allowReconnect error:(NSError *)error {
+    self.webSocket = nil;
+    // notify delegate about the disconnection
+	if ([self.delegate respondsToSelector:@selector(bullyClientDidDisconnect:)]) { // deprecated method call
+		[self.delegate bullyClientDidDisconnect:self];
+	}
+    if ([self.delegate respondsToSelector:@selector(bullyClient:didDisconnectWithError:)]) {
+		[self.delegate bullyClient:self didDisconnectWithError:error];
+	}
+	self.socketID = nil;
+    
+    // If we are not allowed to reconnect due to the pusher connection protocol
+    // or if we shouldn't auto reconnect, stop
+	if (!allowReconnect || !_automaticallyReconnect) {
+		return;
+	}
+    
+	// If it disconnected but Pusher is reachable
+	if ([_reachability isReachable]) {
+#if TARGET_OS_IPHONE
+		// If the app is in the background and we automatically disconnect in the background, don't reconnect. Duh.
+		if (_appIsBackgrounded && _automaticallyDisconnectInBackground) {
+			return;
+		}
+#endif
+		[self connect];
+	}
+}
+
+
+- (void)_reconnectAfterDelay {
+    // TODO: add delegate method?
+    // bullyClient:WillReconnectAfterDelay:
+#if DEBUG
+	NSLog(@"[Bully] Reconnecting after 3 seconds delay");
+#endif
+    
+    // back off for 3 seconds
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC);
+    dispatch_after(timeout, dispatch_get_main_queue(), ^(void){
+        if (_automaticallyReconnect) {
+            [self connect];
+        }
+    });
 }
 
 
@@ -349,13 +380,37 @@
 
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error {
 //	NSLog(@"webSocket:didFailWithError: %@", error);
-	self.webSocket = nil;
+	[self _handleDisconnectAllowAutomaticReconnect:NO error:error];
+    [self _reconnectAfterDelay];
 }
 
 
 - (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean {
 //	NSLog(@"webSocket:didCloseWithCode: %i reason: %@ wasClean: %i", code, reason, wasClean);
-	[self disconnect];
+	
+    // check for error codes based on the Pusher Websocket protocol
+    // see http://pusher.com/docs/pusher_protocol
+    // protocol >= 6 also exposes a human-readable reason why the disconnect happened
+    NSError *error = [NSError errorWithDomain:BLYClientErrorDomain code:code userInfo:@{@"reason": reason}];
+    
+    // 4000-4099 -> The connection SHOULD NOT be re-established unchanged.
+    if (code >= 4000 && code <= 4099) {
+        // do not reconnect
+        [self _handleDisconnectAllowAutomaticReconnect:NO error:error];
+        return;
+    }
+    
+    // 4200-4299 -> The connection SHOULD be re-established immediately.
+    if(code >= 4200 && code <= 4299) {
+        // connect immediately
+        [self _handleDisconnectAllowAutomaticReconnect:YES error:error];
+        return;
+    }
+    
+    // handle all other error codes
+    // i.e. 4100-4199 -> The connection SHOULD be re-established after backing off.
+    [self _handleDisconnectAllowAutomaticReconnect:NO error:error];
+    [self _reconnectAfterDelay];
 }
 
 @end

--- a/Bully/BLYClient.m
+++ b/Bully/BLYClient.m
@@ -179,8 +179,8 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 	}
 
 	// in case the connection was disconnected
-    // do not reconnect automatically
-    [self _handleDisconnectAllowAutomaticReconnect:NO error:nil];
+	// do not reconnect automatically
+	[self _handleDisconnectAllowAutomaticReconnect:NO error:nil];
 }
 
 
@@ -227,18 +227,18 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 
 
 - (void)_handleDisconnectAllowAutomaticReconnect:(BOOL)allowReconnect error:(NSError *)error {
-    self.webSocket = nil;
-    // notify delegate about the disconnection
+	self.webSocket = nil;
+	// notify delegate about the disconnection
 	if ([self.delegate respondsToSelector:@selector(bullyClientDidDisconnect:)]) { // deprecated method call
 		[self.delegate bullyClientDidDisconnect:self];
 	}
-    if ([self.delegate respondsToSelector:@selector(bullyClient:didDisconnectWithError:)]) {
+	if ([self.delegate respondsToSelector:@selector(bullyClient:didDisconnectWithError:)]) {
 		[self.delegate bullyClient:self didDisconnectWithError:error];
 	}
 	self.socketID = nil;
     
-    // If we are not allowed to reconnect due to the pusher connection protocol
-    // or if we shouldn't auto reconnect, stop
+	// If we are not allowed to reconnect due to the pusher connection protocol
+	// or if we shouldn't auto reconnect, stop
 	if (!allowReconnect || !_automaticallyReconnect) {
 		return;
 	}
@@ -257,19 +257,19 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 
 
 - (void)_reconnectAfterDelay {
-    // TODO: add delegate method?
-    // bullyClient:WillReconnectAfterDelay:
+	// TODO: add delegate method?
+	// bullyClient:WillReconnectAfterDelay:
 #if DEBUG
 	NSLog(@"[Bully] Reconnecting after 3 seconds delay");
 #endif
     
-    // back off for 3 seconds
-    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC);
-    dispatch_after(timeout, dispatch_get_main_queue(), ^(void){
-        if (_automaticallyReconnect) {
-            [self connect];
-        }
-    });
+	// back off for 3 seconds
+	dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC);
+	dispatch_after(timeout, dispatch_get_main_queue(), ^(void){
+		if (_automaticallyReconnect) {
+			[self connect];
+		}
+	});
 }
 
 
@@ -381,36 +381,36 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error {
 //	NSLog(@"webSocket:didFailWithError: %@", error);
 	[self _handleDisconnectAllowAutomaticReconnect:NO error:error];
-    [self _reconnectAfterDelay];
+	[self _reconnectAfterDelay];
 }
 
 
 - (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean {
 //	NSLog(@"webSocket:didCloseWithCode: %i reason: %@ wasClean: %i", code, reason, wasClean);
 	
-    // check for error codes based on the Pusher Websocket protocol
-    // see http://pusher.com/docs/pusher_protocol
-    // protocol >= 6 also exposes a human-readable reason why the disconnect happened
-    NSError *error = [NSError errorWithDomain:BLYClientErrorDomain code:code userInfo:@{@"reason": reason}];
+	// check for error codes based on the Pusher Websocket protocol
+	// see http://pusher.com/docs/pusher_protocol
+	// protocol >= 6 also exposes a human-readable reason why the disconnect happened
+	NSError *error = [NSError errorWithDomain:BLYClientErrorDomain code:code userInfo:@{@"reason": reason}];
     
-    // 4000-4099 -> The connection SHOULD NOT be re-established unchanged.
-    if (code >= 4000 && code <= 4099) {
-        // do not reconnect
-        [self _handleDisconnectAllowAutomaticReconnect:NO error:error];
-        return;
+	// 4000-4099 -> The connection SHOULD NOT be re-established unchanged.
+	if (code >= 4000 && code <= 4099) {
+		// do not reconnect
+		[self _handleDisconnectAllowAutomaticReconnect:NO error:error];
+		return;
+	}
+    
+	// 4200-4299 -> The connection SHOULD be re-established immediately.
+	if(code >= 4200 && code <= 4299) {
+		// connect immediately
+		[self _handleDisconnectAllowAutomaticReconnect:YES error:error];
+		return;
     }
     
-    // 4200-4299 -> The connection SHOULD be re-established immediately.
-    if(code >= 4200 && code <= 4299) {
-        // connect immediately
-        [self _handleDisconnectAllowAutomaticReconnect:YES error:error];
-        return;
-    }
-    
-    // handle all other error codes
-    // i.e. 4100-4199 -> The connection SHOULD be re-established after backing off.
-    [self _handleDisconnectAllowAutomaticReconnect:NO error:error];
-    [self _reconnectAfterDelay];
+	// handle all other error codes
+	// i.e. 4100-4199 -> The connection SHOULD be re-established after backing off.
+	[self _handleDisconnectAllowAutomaticReconnect:NO error:error];
+	[self _reconnectAfterDelay];
 }
 
 @end

--- a/Bully/BLYClientPrivate.h
+++ b/Bully/BLYClientPrivate.h
@@ -25,6 +25,8 @@
 - (void)_reconnectChannels;
 - (void)_removeChannel:(BLYChannel *)channel;
 - (void)_reachabilityChanged:(NSNotification *)notification;
+- (void)_handleDisconnectAllowAutomaticReconnect:(BOOL)allowReconnect error:(NSError *)error;
+- (void)_reconnectAfterDelay;
 
 #if TARGET_OS_IPHONE
 - (void)_appDidEnterBackground:(NSNotification *)notificaiton;


### PR DESCRIPTION
See the [Pusher Websocket Protocol](http://pusher.com/docs/pusher_protocol) for further details.
- changed to Pusher protocol version 6 (now supports close codes with error messages)
- added better connection close handling (e.g. do not try to reconnect if the app key is not valid, as this would put unnecessary load on the Pusher servers)
- if the connection is manually closed by the user, do not try to reconnect automatically (to impose the same behaviour as the Pusher Javascript client)
- changed `bullyClientDidDisconnect:` in favor of `bullyClientDidDisconnect:withError:` to expose why the client was disconnected
