### PR TITLE
Various enchantments

### DIFF
--- a/Bully/BLYChannel.m
+++ b/Bully/BLYChannel.m
@@ -58,10 +58,9 @@
 - (void)subscribeWithAuthentication:(NSDictionary *)authentication {
 	NSDictionary *dictionary = nil;
 	if (authentication) {
-		dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:
-					  self.name, @"channel",
-					  [authentication objectForKey:@"auth"], @"auth",
-					  nil];
+		NSMutableDictionary *authenticationCopy = [authentication mutableCopy];
+		authenticationCopy[ @"channel" ] = self.name;
+		dictionary = [authenticationCopy copy];
 	} else {
 		dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:
 					  self.name, @"channel",

--- a/Bully/BLYChannel.m
+++ b/Bully/BLYChannel.m
@@ -39,7 +39,7 @@
 
 
 - (BOOL)isPrivate {
-	return [self.name hasPrefix:@"private-"];
+	return [self.name hasPrefix:@"private-"] || [self.name hasPrefix:@"presence-"];
 }
 
 

--- a/Bully/BLYClient.h
+++ b/Bully/BLYClient.h
@@ -59,5 +59,6 @@ extern NSString *const BLYClientErrorDomain;
 - (void)bullyClient:(BLYClient *)client didReceiveError:(NSError *)error;
 - (void)bullyClientDidDisconnect:(BLYClient *)client __attribute__((deprecated("Use bullyClient:didDisconnectWithError instead")));
 - (void)bullyClient:(BLYClient *)client didDisconnectWithError:(NSError *)error;
+- (void)bullyClient:(BLYClient *)client didJoinChannel:(BLYChannel *)channel;
 
 @end

--- a/Bully/BLYClient.h
+++ b/Bully/BLYClient.h
@@ -40,6 +40,7 @@ extern NSString *const BLYClientErrorDomain;
 - (BLYChannel *)subscribeToChannelWithName:(NSString *)channelName authenticationBlock:(BLYChannelAuthenticationBlock)authenticationBlock errorBlock:(BLYErrorBlock)errorBlock;
 
 // Unsubscribe all
+- (void)unsubscribeChannelWithName:(NSString *)channelName;
 - (void)unsubscribeAll;
 
 // Managing the Connection

--- a/Bully/BLYClient.h
+++ b/Bully/BLYClient.h
@@ -32,6 +32,7 @@ extern NSString *const BLYClientErrorDomain;
 // Initializer
 - (id)initWithAppKey:(NSString *)appKey delegate:(id<BLYClientDelegate>)delegate;
 - (id)initWithAppKey:(NSString *)appKey delegate:(id<BLYClientDelegate>)delegate hostName:(NSString *)hostName;
+- (id)initWithAppKey:(NSString *)appKey delegate:(id<BLYClientDelegate>)delegate hostName:(NSString *)hostName connectAutomatically:(BOOL)connectAutomatically;
 
 // Subscribing
 - (BLYChannel *)subscribeToChannelWithName:(NSString *)channelName;

--- a/Bully/BLYClient.m
+++ b/Bully/BLYClient.m
@@ -358,15 +358,22 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 		[self _reconnectChannels];
 		return;
 	}
-
+	
 	// Check for channel events
 	NSString *channelName = [message objectForKey:@"channel"];
 	if (channelName) {
 		// Find channel
 		BLYChannel *channel = [self.connectedChannels objectForKey:channelName];
-
+		
 		// Ensure the user is subscribed to the channel
 		if (channel) {
+			if ([eventName isEqualToString:@"pusher_internal:subscription_succeeded"]) {
+				// connected to the channel
+				if ([self.delegate respondsToSelector:@selector(bullyClient:didJoinChannel:)]) {
+					[self.delegate bullyClient:self didJoinChannel:channel];
+				}
+				return;
+			}
 
             if (jsonError != nil && channel.errorBlock != nil) {
                 channel.errorBlock(jsonError, BLYErrorTypeJSONParser);

--- a/Bully/BLYClient.m
+++ b/Bully/BLYClient.m
@@ -154,6 +154,12 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 
 #pragma mark - Unsubscribe all
 
+- (void)unsubscribeChannelWithName:(NSString *)channelName
+{
+	BLYChannel *channel = self.connectedChannels[ channelName ];
+	[channel unsubscribe];
+}
+
 - (void)unsubscribeAll {
     NSArray *channels = [_connectedChannels allValues];
     [channels makeObjectsPerformSelector:@selector(unsubscribe)];

--- a/Bully/BLYClient.m
+++ b/Bully/BLYClient.m
@@ -82,6 +82,10 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 }
 
 - (id)initWithAppKey:(NSString *)appKey delegate:(id<BLYClientDelegate>)delegate hostName:(NSString *)hostName {
+	return [self initWithAppKey:appKey delegate:delegate hostName:hostName connectAutomatically:YES];
+}
+
+- (id)initWithAppKey:(NSString *)appKey delegate:(id<BLYClientDelegate>)delegate hostName:(NSString *)hostName connectAutomatically:(BOOL)connectAutomatically {
     if ((self = [super init])) {
 		self.appKey = appKey;
 		self.delegate = delegate;
@@ -115,7 +119,9 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 		[notificationCenter addObserver:self selector:@selector(_reachabilityChanged:) name:kReachabilityChangedNotification object:nil];
 
 		// Connect!
-		[self connect];
+		if (connectAutomatically) {
+			[self connect];
+		}
 	}
 	return self;
 }

--- a/Bully/BLYClient.m
+++ b/Bully/BLYClient.m
@@ -308,7 +308,7 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 
 	_appIsBackgrounded = NO;
 
-	if (_automaticallyDisconnectInBackground) {
+	if (_automaticallyDisconnectInBackground && _automaticallyReconnect) {
 		[self connect];
 	}
 }
@@ -316,6 +316,11 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 
 
 - (void)_reachabilityChanged:(NSNotification *)notification {
+	// user didn't ask for automatic reconnection
+	if (!_automaticallyReconnect) {
+		return;
+	}
+	
 #if TARGET_OS_IPHONE
 	// If the app is in the background, ignore the notificaiton
 	if (_appIsBackgrounded) {

--- a/Bully/BLYClient.m
+++ b/Bully/BLYClient.m
@@ -141,6 +141,7 @@ NSString *const BLYClientErrorDomain = @"BLYClientErrorDomain";
 - (BLYChannel *)subscribeToChannelWithName:(NSString *)channelName authenticationBlock:(BLYChannelAuthenticationBlock)authenticationBlock errorBlock:(BLYErrorBlock)errorBlock {
     BLYChannel *channel = [_connectedChannels objectForKey:channelName];
 	if (channel) {
+		[channel _subscribe];
 		return channel;
 	}
 


### PR DESCRIPTION
Added following features / fixes:
- pusher sometimes complaining about missing fields (SHA mismatch) when sending authentication for channel, fix is backward compatible, just adds all fields from authentication object received from a server
- added ability to unsubscribe from a particular channel by name through `BLYClient`
- delegate method for channel did subscription event - since it is an internal pusher even I think following encapsulation pattern it should be handled by the library itself and not through binding events
- automatic reconnection for some reason wasn't respected when ratability changes (maybe I misunderstood original intent of `automaticallyReconnect` flag)
- Added support for `ping/pong` events that solves connectivity issues on 3G with some carriers and makes library compliant with pusher protocol version 6
